### PR TITLE
 Mobile-bridge: enable depending on plugin config, ReverseProxy refactor, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,22 @@ jobs:
           go test ./... -v -race -count=1 -coverprofile=coverage.out
           go tool cover -func=coverage.out
 
+  test-mobile-bridge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: false # standalone module with no external dependencies
+
+      - name: Vet & Test
+        working-directory: mobile-bridge
+        run: |
+          go vet ./...
+          go test ./... -race -count=1
+
   lint-server:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -186,6 +202,7 @@ jobs:
   # Dockerfile); on pushes to main and on tags it is pushed to the GitHub
   # Container Registry (ghcr.io/<owner>/<repo>/mobile-bridge).
   build-mobile-bridge:
+    needs: test-mobile-bridge
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,12 @@ jobs:
 
   test-mobile-bridge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:

--- a/AGENT.md
+++ b/AGENT.md
@@ -42,7 +42,7 @@ docker-compose -f docker-compose.dev.yml up -d
 - `oauth2.go` — Full OAuth2 flow: state generation with HMAC-SHA256 signing, authorization redirect, callback handling, ID token verification via JWKS, user claim extraction, Mattermost user creation/linking, session cookie management. Also contains the **mobile branch**: `mobile_redirect` is read on `/oauth2/connect` and validated against `allowedMobileSchemes` (`mmauth://callback`, `mmauthbeta://callback` — exact match or `…?`-prefixed; anything else is rejected and logged). The redirect target is carried through the signed state (`MobileRedirect`); when set, the callback uses `SessionLengthMobileInHours`, marks the session with `model.UserAuthServiceIsMobile`, and instead of setting the `MMAUTHTOKEN` cookie hands the token back via `renderMobileAuthComplete` (an HTML auto-redirect page to the app's custom URL scheme with `MMAUTHTOKEN` + `MMCSRF` appended), mirroring core's `utils.RenderMobileAuthComplete`.
 - `configuration.go` — Configuration struct with validation (requires discovery endpoint, client ID/secret, "openid" scope)
 
-**Mobile bridge (Go):** `mobile-bridge/` is an optional, standalone reverse-proxy shim (separate `go.mod`, own `main.go`, `Dockerfile`, `README.md`) that enables native-app OIDC login on servers without the built-in OpenID provider. It is **not** part of the plugin bundle. It sits in the ingress and intercepts two paths: `/api/v4/config/client` (injects `EnableSignUpWithOpenId=true` for mobile UAs only, so the app shows the OpenID button) and `/oauth/openid/mobile_login` (302-redirects into the plugin's `/oauth2/connect?mobile_redirect=…`). Everything else passes through to Mattermost untouched. Button text/color default to values pulled from the plugin's public config. Configured via env vars (`UPSTREAM`, `LISTEN`, `MOBILE_UA_MATCH`, `OPENID_BUTTON_TEXT`/`COLOR`, …). See `mobile-bridge/README.md` for ingress wiring (nginx/Traefik/Caddy) and the licensing caveat. The `docker-compose.dev.yml` includes the bridge for local testing.
+**Mobile bridge (Go):** `mobile-bridge/` is an optional, standalone reverse-proxy shim (separate `go.mod`, own `main.go`, `Dockerfile`, `README.md`) that enables native-app OIDC login on servers without the built-in OpenID provider. It is **not** part of the plugin bundle. It sits in the ingress and intercepts two paths: `/api/v4/config/client` (via an `httputil.ReverseProxy` + `ModifyResponse` hook; injects `EnableSignUpWithOpenId=true` for mobile UAs only — **and only when the plugin's public config reports `enable=true`**, so the app never shows a button that dead-ends) and `/oauth/openid/mobile_login` (302-redirects into the plugin's `/oauth2/connect?mobile_redirect=…`). Everything else passes through to Mattermost untouched (web/desktop responses stream through with their original encoding). Button text/color default to values pulled from the plugin's public config (`enable`/button fields cached ~60s). Covered by `mobile-bridge/main_test.go`. Configured via env vars (`UPSTREAM`, `LISTEN`, `MOBILE_UA_MATCH`, `OPENID_BUTTON_TEXT`/`COLOR`, …). See `mobile-bridge/README.md` for ingress wiring (nginx/Traefik/Caddy) and the licensing caveat. The `docker-compose.dev.yml` includes the bridge for local testing.
 
 **Webapp (React):** Single file `webapp/src/index.js` exporting a Mattermost plugin class:
 - `OIDCLoginButton` component fetches public config from `/api/v1/config` and renders a styled login button
@@ -59,10 +59,12 @@ GitHub Actions (`.github/workflows/ci.yml`) mit folgenden Jobs:
 
 - `set-version` — Liest Version aus Git-Tag (`v1.2.0 → 1.2.0`) oder `plugin.json`
 - `test-server` — `go test ./... -race -coverprofile`
+- `test-mobile-bridge` — `go vet` + `go test -race` im `mobile-bridge`-Modul
 - `lint-server` — `golangci-lint` (non-blocking)
 - `build-server` — Cross-compile für `linux/darwin × amd64/arm64`
 - `build-webapp` — `npm ci && npm run build`
 - `build-bundle` — Packt alle Artefakte zu `.tar.gz`
+- `build-mobile-bridge` — Multi-arch Container-Image (ghcr.io), gated auf `test-mobile-bridge`
 - `release` — Erstellt GitHub Release mit Changelog (nur bei `v*`-Tags)
 
 Dependabot (`.github/dependabot.yml`) aktualisiert wöchentlich Go-Module, npm-Pakete und GitHub Actions.

--- a/mobile-bridge/README.md
+++ b/mobile-bridge/README.md
@@ -148,9 +148,11 @@ chat.example.com {
 
 ## Troubleshooting
 
-- **No button in the app** → the config rewrite isn't matching. Run the shim with
-  `DEBUG=1` and watch the logged `User-Agent`; adjust `MOBILE_UA_MATCH`. Confirm
-  the ingress actually routes `/api/v4/config/client` to the shim.
+- **No button in the app** → the config rewrite isn't matching. The shim only
+  advertises the button when the plugin's public config reports `enable=true`, so
+  first confirm OIDC is **enabled** and working for web login. Then run the shim
+  with `DEBUG=1` and watch the logged `User-Agent`; adjust `MOBILE_UA_MATCH`.
+  Confirm the ingress actually routes `/api/v4/config/client` to the shim.
 - **Button appears, login fails after IdP** → check the plugin server logs.
   The app needs a non-empty `MMCSRF`; the plugin sets one. Verify the deep link
   scheme matches your app build (prod `mmauth://`, beta `mmauthbeta://`) — the

--- a/mobile-bridge/main.go
+++ b/mobile-bridge/main.go
@@ -6,10 +6,11 @@
 //
 //  1. GET /api/v4/config/client
 //     For requests coming from the native app (User-Agent contains
-//     "Mattermost Mobile/"), it rewrites the JSON config to advertise the
-//     built-in OpenID provider so the app renders its native "Open ID" login
-//     button. All other clients (web, desktop) get the upstream response
-//     untouched, so they keep using the plugin's own login button.
+//     "Mattermost Mobile/") — and only when the plugin reports OIDC is enabled —
+//     it rewrites the JSON config to advertise the built-in OpenID provider so
+//     the app renders its native "Open ID" login button. All other clients (web,
+//     desktop) get the upstream response untouched, so they keep using the
+//     plugin's own login button.
 //
 //  2. GET /oauth/openid/mobile_login
 //     The native SSO flow targets this hardcoded core endpoint. The shim
@@ -24,14 +25,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -70,18 +74,6 @@ func loadConfig() config {
 	}
 }
 
-// hopByHop headers must not be forwarded between connections.
-var hopByHop = map[string]bool{
-	"Connection":          true,
-	"Keep-Alive":          true,
-	"Proxy-Authenticate":  true,
-	"Proxy-Authorization": true,
-	"Te":                  true,
-	"Trailer":             true,
-	"Transfer-Encoding":   true,
-	"Upgrade":             true,
-}
-
 // pluginPublicConfig mirrors the plugin's GET /api/v1/config response.
 type pluginPublicConfig struct {
 	Enable      bool   `json:"enable"`
@@ -89,9 +81,9 @@ type pluginPublicConfig struct {
 	ButtonColor string `json:"button_color"`
 }
 
-// buttonCache caches the plugin's button text/color so it is not refetched on
-// every config request. Concurrency-safe; refreshes after ttl, and keeps the
-// last good value if a refresh fails.
+// buttonCache caches the plugin's public config (enable flag + button text/color)
+// so it is not refetched on every config request. Concurrency-safe; refreshes
+// after ttl, and keeps the last good value if a refresh fails.
 type buttonCache struct {
 	mu        sync.Mutex
 	ttl       time.Duration
@@ -155,102 +147,143 @@ func fetchPluginConfig(cfg config, client *http.Client) (pluginPublicConfig, err
 	return pc, nil
 }
 
-func main() {
-	cfg := loadConfig()
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		// Do not auto-follow redirects when proxying the config endpoint.
-		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+// matchesMobileUA reports whether the User-Agent identifies the native app.
+func matchesMobileUA(ua, match string) bool {
+	return match != "" && strings.Contains(ua, match)
+}
+
+// newHandler builds the shim's HTTP handler: a reverse proxy for the client-config
+// route (rewriting the body for mobile via ModifyResponse), the mobile_login
+// redirect, and a health check. Only these routes should reach the shim; the
+// ingress sends everything else straight to Mattermost.
+func newHandler(cfg config, client *http.Client, cache *buttonCache) http.Handler {
+	target, err := url.Parse(cfg.upstream)
+	if err != nil {
+		log.Fatalf("invalid UPSTREAM %q: %v", cfg.upstream, err)
 	}
-	cache := &buttonCache{ttl: 60 * time.Second}
+
+	// Reverse proxy for /api/v4/config/client. Using httputil.ReverseProxy gives us
+	// correct hop-by-hop header handling and streaming for free; we only intervene
+	// in Rewrite (routing + forwarding headers) and ModifyResponse (native app).
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)  // route to upstream (also sets the Host header)
+			pr.SetXForwarded() // add X-Forwarded-For/-Host/-Proto (Rewrite omits these)
+			// Only the mobile response is buffered and rewritten, so force an
+			// uncompressed body for it. Web/desktop stream through with whatever
+			// encoding upstream negotiated.
+			if matchesMobileUA(pr.Out.Header.Get("User-Agent"), cfg.mobileUAMatch) {
+				pr.Out.Header.Set("Accept-Encoding", "identity")
+			}
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			return rewriteClientConfig(cfg, client, cache, resp)
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			log.Printf("upstream error: %v", err)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		},
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	})
-	mux.HandleFunc("/api/v4/config/client", func(w http.ResponseWriter, r *http.Request) {
-		handleClientConfig(cfg, client, cache, w, r)
-	})
+	mux.Handle("/api/v4/config/client", proxy)
 	mux.HandleFunc("/oauth/openid/mobile_login", func(w http.ResponseWriter, r *http.Request) {
 		handleMobileLogin(cfg, w, r)
 	})
+	return mux
+}
+
+func main() {
+	cfg := loadConfig()
+	client := &http.Client{Timeout: 30 * time.Second}
+	cache := &buttonCache{ttl: 60 * time.Second}
 
 	log.Printf("mobile-bridge listening on %s, upstream=%s, ua-match=%q", cfg.listen, cfg.upstream, cfg.mobileUAMatch)
-	if err := http.ListenAndServe(cfg.listen, mux); err != nil {
+	if err := http.ListenAndServe(cfg.listen, newHandler(cfg, client, cache)); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
 }
 
-// handleClientConfig proxies GET /api/v4/config/client to upstream and, for the
-// native mobile app, flips on the OpenID login button in the returned JSON.
-func handleClientConfig(cfg config, client *http.Client, cache *buttonCache, w http.ResponseWriter, r *http.Request) {
-	upReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, cfg.upstream+r.URL.RequestURI(), nil)
-	if err != nil {
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
-	}
-	upReq.Header = r.Header.Clone()
-	// Force an uncompressed response so we can rewrite the JSON without juggling gzip.
-	upReq.Header.Set("Accept-Encoding", "identity")
-
-	resp, err := client.Do(upReq)
-	if err != nil {
-		log.Printf("upstream error: %v", err)
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
-	}
-
-	ua := r.Header.Get("User-Agent")
-	isMobile := cfg.mobileUAMatch != "" && strings.Contains(ua, cfg.mobileUAMatch)
+// rewriteClientConfig, for the native mobile app only, flips on the OpenID login
+// button in the /api/v4/config/client JSON — but only when the plugin's public
+// config reports OIDC is enabled, so the app never shows a button that dead-ends
+// at "OIDC authentication is not enabled".
+func rewriteClientConfig(cfg config, client *http.Client, cache *buttonCache, resp *http.Response) error {
+	ua := resp.Request.Header.Get("User-Agent")
+	isMobile := matchesMobileUA(ua, cfg.mobileUAMatch)
 	if cfg.debug {
 		log.Printf("config/client ua=%q mobile=%v status=%d", ua, isMobile, resp.StatusCode)
 	}
-
-	if isMobile && resp.StatusCode == http.StatusOK {
-		var m map[string]string
-		if json.Unmarshal(body, &m) == nil {
-			m["EnableSignUpWithOpenId"] = "true"
-
-			// Button text/color: explicit env vars win; otherwise pull them from
-			// the plugin's own public config so the mobile button matches web.
-			text, color := cfg.openIDButtonText, cfg.openIDButtonColor
-			if text == "" || color == "" {
-				if pc, ok := cache.get(cfg, client); ok {
-					if text == "" {
-						text = pc.ButtonText
-					}
-					if color == "" {
-						color = pc.ButtonColor
-					}
-				}
-			}
-			if text != "" {
-				m["OpenIdButtonText"] = text
-			}
-			if color != "" {
-				m["OpenIdButtonColor"] = color
-			}
-			if nb, e := json.Marshal(m); e == nil {
-				body = nb
-			}
-		} else if cfg.debug {
-			log.Printf("config/client: body was not a JSON object, passing through")
-		}
+	if !isMobile || resp.StatusCode != http.StatusOK {
+		return nil
 	}
 
-	copyHeaders(w.Header(), resp.Header)
-	w.Header().Del("Content-Encoding") // body is identity
-	w.Header().Del("Content-Length")   // length changed
-	w.WriteHeader(resp.StatusCode)
-	_, _ = w.Write(body)
+	// The plugin's public config is the single source of truth for whether the
+	// mobile button should appear and what it looks like. If it is unreachable or
+	// reports disabled, leave the config untouched — no button.
+	pc, ok := cache.get(cfg, client)
+	if !ok || !pc.Enable {
+		if cfg.debug {
+			log.Printf("config/client: plugin unreachable or disabled (ok=%v enable=%v), not advertising OpenID", ok, pc.Enable)
+		}
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+
+	var m map[string]string
+	if err := json.Unmarshal(body, &m); err != nil {
+		// Not a JSON object we understand — pass the original body through untouched.
+		if cfg.debug {
+			log.Printf("config/client: body was not a JSON object, passing through")
+		}
+		resetBody(resp, body)
+		return nil
+	}
+
+	m["EnableSignUpWithOpenId"] = "true"
+
+	// Button text/color: explicit env vars win; otherwise pull them from the
+	// plugin's own public config so the mobile button matches web.
+	text, color := cfg.openIDButtonText, cfg.openIDButtonColor
+	if text == "" {
+		text = pc.ButtonText
+	}
+	if color == "" {
+		color = pc.ButtonColor
+	}
+	if text != "" {
+		m["OpenIdButtonText"] = text
+	}
+	if color != "" {
+		m["OpenIdButtonColor"] = color
+	}
+
+	nb, err := json.Marshal(m)
+	if err != nil {
+		resetBody(resp, body)
+		return nil
+	}
+	resetBody(resp, nb)
+	return nil
+}
+
+// resetBody replaces a response body with the given bytes and fixes up the
+// framing headers. The body is always identity-encoded here (forced for mobile
+// in the Director), so any stale Content-Encoding is dropped.
+func resetBody(resp *http.Response, body []byte) {
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	resp.Header.Del("Content-Encoding")
 }
 
 // handleMobileLogin turns the native app's /oauth/openid/mobile_login request
@@ -267,15 +300,4 @@ func handleMobileLogin(cfg config, w http.ResponseWriter, r *http.Request) {
 		log.Printf("mobile_login redirect_to=%q -> %s", redirectTo, loc)
 	}
 	http.Redirect(w, r, loc, http.StatusFound)
-}
-
-func copyHeaders(dst, src http.Header) {
-	for k, vv := range src {
-		if hopByHop[k] {
-			continue
-		}
-		for _, v := range vv {
-			dst.Add(k, v)
-		}
-	}
 }

--- a/mobile-bridge/main.go
+++ b/mobile-bridge/main.go
@@ -239,7 +239,11 @@ func rewriteClientConfig(cfg config, client *http.Client, cache *buttonCache, re
 	}
 	_ = resp.Body.Close()
 
-	var m map[string]string
+	// Deserialize into map[string]any rather than map[string]string: Mattermost's
+	// client config is flat string values today, but decoding into `any` means a
+	// future nested field won't fail the whole unmarshal and silently drop the
+	// button injection.
+	var m map[string]any
 	if err := json.Unmarshal(body, &m); err != nil {
 		// Not a JSON object we understand — pass the original body through untouched.
 		if cfg.debug {

--- a/mobile-bridge/main_test.go
+++ b/mobile-bridge/main_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	mobileUA = "Mattermost Mobile/2.42.0+1 (iOS; 17; iPhone)"
+	webUA    = "Mozilla/5.0 Mattermost/5.7 Electron"
+	cfgPath  = "/plugins/mattermost-oidc/api/v1/config"
+)
+
+func TestMatchesMobileUA(t *testing.T) {
+	cases := []struct {
+		ua, match string
+		want      bool
+	}{
+		{mobileUA, "Mattermost Mobile/", true},
+		{webUA, "Mattermost Mobile/", false},
+		{mobileUA, "", false}, // empty match never matches
+		{"", "Mattermost Mobile/", false},
+	}
+	for _, c := range cases {
+		if got := matchesMobileUA(c.ua, c.match); got != c.want {
+			t.Errorf("matchesMobileUA(%q, %q) = %v, want %v", c.ua, c.match, got, c.want)
+		}
+	}
+}
+
+func TestHandleMobileLogin(t *testing.T) {
+	cfg := config{pluginConnectPath: "/plugins/mattermost-oidc/oauth2/connect"}
+
+	t.Run("redirects with mobile_redirect", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/oauth/openid/mobile_login?redirect_to=mmauth%3A%2F%2Fcallback", nil)
+		rec := httptest.NewRecorder()
+		handleMobileLogin(cfg, rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+		}
+		loc := rec.Header().Get("Location")
+		want := "/plugins/mattermost-oidc/oauth2/connect?mobile_redirect=mmauth%3A%2F%2Fcallback"
+		if loc != want {
+			t.Errorf("Location = %q, want %q", loc, want)
+		}
+	})
+
+	t.Run("missing redirect_to is 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/oauth/openid/mobile_login", nil)
+		rec := httptest.NewRecorder()
+		handleMobileLogin(cfg, rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+// newTestUpstream returns a server that answers both the client-config route and
+// the plugin public-config route (both live behind the same upstream host).
+func newTestUpstream(enable bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v4/config/client":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"Version":"1","EnableSignUpWithOpenId":"false"}`)
+		case cfgPath:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enable":       enable,
+				"button_text":  "SSO Login",
+				"button_color": "#123456",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// getClientConfig runs a request through the shim (with a plugin reporting the
+// given enable state) and returns the decoded /api/v4/config/client JSON object.
+func getClientConfig(t *testing.T, cfg config, ua string, enable bool) map[string]string {
+	t.Helper()
+	upstream := newTestUpstream(enable)
+	defer upstream.Close()
+	cfg.upstream = upstream.URL
+
+	shim := httptest.NewServer(newHandler(cfg, &http.Client{Timeout: 5 * time.Second}, &buttonCache{ttl: time.Minute}))
+	defer shim.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, shim.URL+"/api/v4/config/client", nil)
+	req.Header.Set("User-Agent", ua)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var m map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return m
+}
+
+func baseConfig() config {
+	return config{
+		pluginConnectPath: "/plugins/mattermost-oidc/oauth2/connect",
+		pluginConfigPath:  cfgPath,
+		mobileUAMatch:     "Mattermost Mobile/",
+	}
+}
+
+func TestRewriteClientConfig(t *testing.T) {
+	t.Run("mobile + plugin enabled → button advertised", func(t *testing.T) {
+		cfg := baseConfig()
+		m := getClientConfig(t, cfg, mobileUA, true)
+		if m["EnableSignUpWithOpenId"] != "true" {
+			t.Errorf("EnableSignUpWithOpenId = %q, want true", m["EnableSignUpWithOpenId"])
+		}
+		if m["OpenIdButtonText"] != "SSO Login" {
+			t.Errorf("OpenIdButtonText = %q, want %q", m["OpenIdButtonText"], "SSO Login")
+		}
+		if m["OpenIdButtonColor"] != "#123456" {
+			t.Errorf("OpenIdButtonColor = %q, want %q", m["OpenIdButtonColor"], "#123456")
+		}
+	})
+
+	t.Run("mobile + plugin disabled → untouched", func(t *testing.T) {
+		cfg := baseConfig()
+		m := getClientConfig(t, cfg, mobileUA, false)
+		if m["EnableSignUpWithOpenId"] != "false" {
+			t.Errorf("EnableSignUpWithOpenId = %q, want false (plugin disabled)", m["EnableSignUpWithOpenId"])
+		}
+		if _, ok := m["OpenIdButtonText"]; ok {
+			t.Errorf("OpenIdButtonText should not be set when plugin disabled")
+		}
+	})
+
+	t.Run("non-mobile → untouched even when enabled", func(t *testing.T) {
+		cfg := baseConfig()
+		m := getClientConfig(t, cfg, webUA, true)
+		if m["EnableSignUpWithOpenId"] != "false" {
+			t.Errorf("EnableSignUpWithOpenId = %q, want false (web client)", m["EnableSignUpWithOpenId"])
+		}
+	})
+
+	t.Run("env vars override plugin button values", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.openIDButtonText = "Forced Text"
+		cfg.openIDButtonColor = "#ABCDEF"
+		m := getClientConfig(t, cfg, mobileUA, true)
+		if m["OpenIdButtonText"] != "Forced Text" {
+			t.Errorf("OpenIdButtonText = %q, want %q", m["OpenIdButtonText"], "Forced Text")
+		}
+		if m["OpenIdButtonColor"] != "#ABCDEF" {
+			t.Errorf("OpenIdButtonColor = %q, want %q", m["OpenIdButtonColor"], "#ABCDEF")
+		}
+	})
+}
+
+func TestHealthz(t *testing.T) {
+	cfg := baseConfig()
+	cfg.upstream = "http://127.0.0.1:0"
+	shim := httptest.NewServer(newHandler(cfg, &http.Client{Timeout: time.Second}, &buttonCache{ttl: time.Minute}))
+	defer shim.Close()
+
+	resp, err := http.Get(shim.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("healthz request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthz status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.TrimSpace(string(body)) != "ok" {
+		t.Errorf("healthz body = %q, want ok", body)
+	}
+}


### PR DESCRIPTION
- Fix: only advertise the mobile OIDC button when the plugin is actually enabled. The bridge now consults the plugin's public config (enable) before injecting EnableSignUpWithOpenId=true for mobile UAs. Previously a disabled/misconfigured plugin still showed a button that dead-ended at 400 "OIDC authentication is not enabled". The plugin config is now the single source of truth for button visibility/text/color; OPENID_BUTTON_TEXT/COLOR remain overrides.
- Refactor: replace hand-rolled proxy plumbing with httputil.ReverseProxy + ModifyResponse. Removes the manual hop-by-hop map, header copying and body handling (~40 lines). Gains correct hop-by-hop handling and X-Forwarded-For for free, and web/desktop responses now stream through compressed instead of being fully buffered (Accept-Encoding: identity is forced only for the mobile branch).
- Tests + CI: new mobile-bridge/main_test.go (UA matching, mobile_login redirect, config rewrite for enabled/disabled/non-mobile/env-override, healthz). New CI job test-mobile-bridge (go vet + go test -race); build-mobile-bridge is now gated on it. The bridge was previously only docker-built, never tested.
- Docs (AGENT.md, mobile-bridge/README.md) updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mobile bridge handling for native app requests, enabling OpenID-based sign-up in `/api/v4/config/client`.
  * Added configurable OpenID button text and color for mobile responses (with optional environment overrides).
* **Bug Fixes**
  * Mobile config rewriting now applies only to mobile user agents and only when OpenID is enabled.
  * Ensures rewritten responses remain correctly framed/encoded.
* **Tests**
  * Added unit/integration coverage for mobile UA matching, mobile login redirects, config rewriting, and `/healthz`.
* **Chores**
  * CI now runs vet/test for the mobile bridge before building the multi-arch container image.
* **Documentation**
  * Updated mobile troubleshooting steps and CI workflow notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->